### PR TITLE
Fatal error : Correcting case for variable hostname

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -43,7 +43,7 @@ class collectdwin::config (
 
 
   if $hostname != undef {
-    $_hostname = "Hostname=\"${hostname}\""
+    $_hostname = "HostName=\"${hostname}\""
   } else {
     $_hostname = ''
   }


### PR DESCRIPTION
Hi

I'm really sorry but I did a mistake in my last commit :(

The variable "HostName" isn't named correctly and collectdwin doesn't handle very well wrong case ;(

I did some serverspec to check this PR and it works (finally ...) :

Before :
```
chocolatey packages
  Command "choco list -lo"
    exit_status
      should eq 0
    stdout
      should match /collectdwin/
  Service "CollectdWinService"
    should be enabled
    should be installed
    should be running (FAILED - 1)
    should have start mode "Automatic"
```

After :
```
chocolatey packages
  Command "choco list -lo"
    exit_status
      should eq 0
    stdout
      should match /collectdwin/
  Service "CollectdWinService"
    should be enabled
    should be installed
    should be running
    should have start mode "Automatic"
```

Thanks in advance for your work !

Thomas.
